### PR TITLE
Split WUD handling: Use getAbsoluteFile() before getParentFile().

### DIFF
--- a/src/main/java/de/mas/wiiu/jnus/implementations/wud/WUDImage.java
+++ b/src/main/java/de/mas/wiiu/jnus/implementations/wud/WUDImage.java
@@ -132,7 +132,7 @@ public class WUDImage {
     private long calculateSplittedFileSize() {
         long result = 0;
         File filehandlePart1 = getFileHandle();
-        String pathToFiles = filehandlePart1.getParentFile().getAbsolutePath();
+        String pathToFiles = filehandlePart1.getAbsoluteFile().getParentFile().getAbsolutePath();
         for (int i = 1; i <= WUDDiscReaderSplitted.NUMBER_OF_FILES; i++) {
             String filePartPath = pathToFiles + File.separator + String.format(WUDDiscReaderSplitted.WUD_SPLITTED_DEFAULT_FILEPATTERN, i);
             File part = new File(filePartPath);

--- a/src/main/java/de/mas/wiiu/jnus/implementations/wud/reader/WUDDiscReaderSplitted.java
+++ b/src/main/java/de/mas/wiiu/jnus/implementations/wud/reader/WUDDiscReaderSplitted.java
@@ -100,7 +100,7 @@ public class WUDDiscReaderSplitted extends WUDDiscReader {
 
     private RandomAccessFile getFileByOffset(long offset) throws IOException {
         File filehandlePart1 = getImage().getFileHandle();
-        String pathToFiles = filehandlePart1.getParentFile().getAbsolutePath();
+        String pathToFiles = filehandlePart1.getAbsoluteFile().getParentFile().getAbsolutePath();
 
         int filePart = getFilePartByOffset(offset);
 


### PR DESCRIPTION
For some reason, on Linux, Java returns null for getParentFile() if we don't explicitly use getAbsoluteFile(). This also happens in a Windows 7 VM when using VirtualBox shared folders.

Both setups used Java 8.